### PR TITLE
Updated Python Install requirements

### DIFF
--- a/Dockerfile.python3
+++ b/Dockerfile.python3
@@ -64,4 +64,6 @@ RUN \
                  python-dateutil==2.6.0 \
                  PyYAML==3.12 \
                  scipy \
-                 xmltodict==0.10.2
+                 xmltodict==0.10.2 \
+                 loky \
+                 repoze.lru


### PR DESCRIPTION
Added Loky, and repoze.lru, since they aren't included in the requirements by default.